### PR TITLE
Fix CORS policy

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -11,8 +11,7 @@ builder.Services.AddCors(options =>
     options.AddPolicy(name: MyAllowSpecificOrigins,
                       policy =>
                       {
-                          policy.WithOrigins("https://swolespace.onrender.com").AllowAnyHeader()
-                                                  .AllowAnyMethod();
+                          policy.WithOrigins("https://swolespace.onrender.com", "http://localhost:3000").AllowAnyHeader().AllowAnyMethod();
                       });
 });
 
@@ -41,13 +40,9 @@ if (app.Environment.IsDevelopment())
     app.UseSwagger();
     app.UseSwaggerUI();
 }
+// Add Cors Policy to only allow from 
 app.UseCors(MyAllowSpecificOrigins);
 
-/*app.UseCors(builder => builder
-       .AllowAnyHeader()
-       .AllowAnyMethod()
-       .AllowAnyOrigin()
-    );*/
 app.UseHttpsRedirection();
 
 app.UseAuthorization();

--- a/Program.cs
+++ b/Program.cs
@@ -6,15 +6,15 @@ var MyAllowSpecificOrigins = "_myAllowSpecificOrigins";
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddCors(options =>
+/*builder.Services.AddCors(options =>
 {
     options.AddPolicy(name: MyAllowSpecificOrigins,
                       policy =>
                       {
-                          policy.WithOrigins("https://swolespace.onrender.com/").AllowAnyHeader()
+                          policy.WithOrigins("https://swolespace.onrender.com/", "swolespace.onrender.com/", "https://www.swolespace.onrender.com/").AllowAnyHeader()
                                                   .AllowAnyMethod();
                       });
-});
+});*/
 
 // Add services to the container.
 
@@ -41,10 +41,14 @@ if (app.Environment.IsDevelopment())
     app.UseSwagger();
     app.UseSwaggerUI();
 }
+//app.UseCors(MyAllowSpecificOrigins);
 
+app.UseCors(builder => builder
+       .AllowAnyHeader()
+       .AllowAnyMethod()
+       .AllowAnyOrigin()
+    );
 app.UseHttpsRedirection();
-
-app.UseCors(MyAllowSpecificOrigins);
 
 app.UseAuthorization();
 

--- a/Program.cs
+++ b/Program.cs
@@ -2,7 +2,18 @@ using HealthApplication.Attributes;
 using HealthApplication.Repositories;
 using HealthApplication.Services;
 
+var MyAllowSpecificOrigins = "_myAllowSpecificOrigins";
+
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy(name: MyAllowSpecificOrigins,
+                      policy =>
+                      {
+                          policy.WithOrigins("https://swolespace.onrender.com/");
+                      });
+});
 
 // Add services to the container.
 
@@ -31,6 +42,8 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
+
+app.UseCors(MyAllowSpecificOrigins);
 
 app.UseAuthorization();
 

--- a/Program.cs
+++ b/Program.cs
@@ -11,7 +11,7 @@ builder.Services.AddCors(options =>
     options.AddPolicy(name: MyAllowSpecificOrigins,
                       policy =>
                       {
-                          policy.WithOrigins("https://swolespace.onrender.com/", "swolespace.onrender.com/", "https://www.swolespace.onrender.com/").AllowAnyHeader()
+                          policy.AllowAnyOrigin.AllowAnyHeader()
                                                   .AllowAnyMethod();
                       });
 });

--- a/Program.cs
+++ b/Program.cs
@@ -6,7 +6,7 @@ var MyAllowSpecificOrigins = "_myAllowSpecificOrigins";
 
 var builder = WebApplication.CreateBuilder(args);
 
-/*builder.Services.AddCors(options =>
+builder.Services.AddCors(options =>
 {
     options.AddPolicy(name: MyAllowSpecificOrigins,
                       policy =>
@@ -14,7 +14,7 @@ var builder = WebApplication.CreateBuilder(args);
                           policy.WithOrigins("https://swolespace.onrender.com/", "swolespace.onrender.com/", "https://www.swolespace.onrender.com/").AllowAnyHeader()
                                                   .AllowAnyMethod();
                       });
-});*/
+});
 
 // Add services to the container.
 
@@ -41,13 +41,13 @@ if (app.Environment.IsDevelopment())
     app.UseSwagger();
     app.UseSwaggerUI();
 }
-//app.UseCors(MyAllowSpecificOrigins);
+app.UseCors(MyAllowSpecificOrigins);
 
-app.UseCors(builder => builder
+/*app.UseCors(builder => builder
        .AllowAnyHeader()
        .AllowAnyMethod()
        .AllowAnyOrigin()
-    );
+    );*/
 app.UseHttpsRedirection();
 
 app.UseAuthorization();

--- a/Program.cs
+++ b/Program.cs
@@ -11,7 +11,8 @@ builder.Services.AddCors(options =>
     options.AddPolicy(name: MyAllowSpecificOrigins,
                       policy =>
                       {
-                          policy.WithOrigins("https://swolespace.onrender.com/");
+                          policy.WithOrigins("https://swolespace.onrender.com/").AllowAnyHeader()
+                                                  .AllowAnyMethod();
                       });
 });
 

--- a/Program.cs
+++ b/Program.cs
@@ -11,7 +11,7 @@ builder.Services.AddCors(options =>
     options.AddPolicy(name: MyAllowSpecificOrigins,
                       policy =>
                       {
-                          policy.AllowAnyOrigin().AllowAnyHeader()
+                          policy.WithOrigins("https://swolespace.onrender.com").AllowAnyHeader()
                                                   .AllowAnyMethod();
                       });
 });

--- a/Program.cs
+++ b/Program.cs
@@ -11,7 +11,7 @@ builder.Services.AddCors(options =>
     options.AddPolicy(name: MyAllowSpecificOrigins,
                       policy =>
                       {
-                          policy.AllowAnyOrigin.AllowAnyHeader()
+                          policy.AllowAnyOrigin().AllowAnyHeader()
                                                   .AllowAnyMethod();
                       });
 });


### PR DESCRIPTION
# Purpose
To add cors policy for front-end and development

# Description
Allows the user to access backend APIs from the front-end application. Also closes #2  `Access to XMLHttpRequest at 'https://xxx.com/' from origin 'https://xxx.com' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource`